### PR TITLE
CSV, content, print

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -510,7 +510,7 @@
           <p class="inline-block right hide-print"><a class="button button-secondary no-decoration" href="#" id="link-about">Start a new search</a></p>
         </div>
       </div>
-      <div class="group" id="results-total">
+      <div class="group hide" id="results-total">
         <div class="col col-3">
           <h1 class="super left inline-block  margin-right-quarter"><a class="ruralCnt no-decoration counter no-decoration" href="#rural">0</a></h1>
           <h4 class="inline-block half-width left padding-top-half"><span class="ruralVerb verb">are</span> designated as rural or underserved</h4>

--- a/src/index.html
+++ b/src/index.html
@@ -610,7 +610,7 @@
             <strong><span class="duplicateCnt counter">0</span></strong> <span class="duplicateCase case">addresses are</span> identified as duplicate
           </h2>
           <p class="col-8">
-            The tool identified these properties as duplicate entries. Duplicate entries are not counted in the other three categories of results. An address appears in the duplicate count because there is more than one identical address in your CSV file. The addresses identified as duplicates should not be included in your more than 50 percent test calculation of rural or underserved properties.
+            These addresses have been identified as duplicate entries, and only the first instance of each address has been counted in the other three categories of results. Duplicates should not be included in your more than 50 percent test calculation of rural or underserved properties.
           </p>
           <p class="col-8">
             To update or remove the information for these addresses, start a new search.

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -103,6 +103,10 @@ $('#geocode').submit(function(e) {
     }
   });
 
+  if (addresses.length > 1) {
+    $('#results-total').removeClass('hide');
+  }
+
   count.updateAddressCount(addresses.length);
   processAddresses(addresses);
   return false;
@@ -176,7 +180,9 @@ $('#geocode-csv').submit(function(e) {
             var leftOver = rowCount - 250;
             fileInput.setError('You entered ' + rowCount + ' addresses for ' + $('#year').val() + ' safe harbor designation. We have a limit of 250 addresses. You can run the first 250 now, but please recheck the remaining ' + leftOver + '.');
           }
-
+          if (addresses.length > 1) {
+            $('#results-total').removeClass('hide');
+          }
           count.updateAddressCount(addresses.length);
           processAddresses(addresses);
         }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -151,7 +151,9 @@ $('#file').change(function(e) {
 
 // on file submission
 $('#geocode-csv').submit(function(e) {
-  if(fileInput.isCSV($('#file').val())) {
+  if ($('#file').val() === '' || $('#file').val() === 'No file chosen' || $('#file').val() === null) {
+    fileInput.setError('You have not selected a file. Use the "Select file" button to select the file with your addresses.');
+  } else if(fileInput.isCSV($('#file').val())) {
     content.setup();
     var rowCount = 0;
     textInputs.reset();

--- a/src/js/misc.js
+++ b/src/js/misc.js
@@ -58,9 +58,6 @@ $(function(){
 
   // print
   $('#print').click(function() {
-    $('tbody tr.data').removeClass('hide');
-    $('.button-more').addClass('hide');
-    $('.view-all').addClass('hide');
     window.print();
   });
 

--- a/src/js/misc.js
+++ b/src/js/misc.js
@@ -58,7 +58,10 @@ $(function(){
 
   // print
   $('#print').click(function() {
-      window.print();
+    $('tbody tr.data').removeClass('hide');
+    $('.button-more').addClass('hide');
+    $('.view-all').addClass('hide');
+    window.print();
   });
 
   // csv download

--- a/src/js/misc.js
+++ b/src/js/misc.js
@@ -103,7 +103,12 @@ $(function(){
   var currentTable = '';
   var firstTable = true;
   function generateCSV() {
-    theCSV = 'Address Entered, Address Identified, County, Census Block, Rural or Underserved?' + '\n';
+    var date = new Date();
+    var day = date.getDate();
+    var monthIndex = date.getMonth();
+    var year = date.getFullYear();
+
+    theCSV = 'Address entered, Address identified, County, Rural or underserved?, Date processed' + '\n';
 
     // loop through each row
     $('.table tbody tr td').each(function () {
@@ -114,7 +119,7 @@ $(function(){
           theCSV = theCSV + ('"' + thisString + '"'); // put the content in first
 
           if ($(this).is(':last-child')) {
-            theCSV = theCSV + '\n';
+            theCSV = theCSV + ',' + monthIndex + '/' + day + '/' + year + '\n';
           } else {
             theCSV = theCSV + ',';
           }

--- a/src/scss/_print.scss
+++ b/src/scss/_print.scss
@@ -8,7 +8,9 @@
     }
 
     #header,
-    #footer {
+    #footer,
+    .button-more,
+    .view-all {
       display: none;
     }
 
@@ -71,5 +73,15 @@
     th,
     td {
       padding: .1em;
+    }
+    tbody tr.data.hide {
+      position: relative;
+      overflow: visible;
+      clip: auto;
+      height: auto;
+      width: auto;
+      margin: 0;
+      padding: 0;
+      border: 0;
     }
 }

--- a/src/scss/_print.scss
+++ b/src/scss/_print.scss
@@ -7,11 +7,6 @@
         display: block;
     }
 
-    .main-header {
-        border-color: $gray-50;
-        border-width: 3px;
-    }
-
     #header,
     #footer {
       display: none;
@@ -21,17 +16,27 @@
       margin-top: 0;
     }
 
-    h1 {
-        font-size: 22px;
+    h1,
+    .super {
+        font-size: 18px;
         margin-top: 0;
     }
 
     h2 {
-        font-size: 20px;
+        font-size: 14px;
+    }
+
+    h4 {
+      font-size: 12px;
     }
 
     h5 {
         font-size: 12px;
+    }
+
+    p {
+      font-size: 12px;
+      line-height: 1;
     }
 
     #logo {
@@ -48,7 +53,7 @@
 
     #results-total {
         background: $gray-10;
-        padding: 10px;
+        padding: 3px;
 
         a.no-decoration {
             border-bottom-style: none;
@@ -59,5 +64,12 @@
 
     [class^="col-"] {
       width: 100%;
+    }
+    table {
+      font-size: 12px;
+    }
+    th,
+    td {
+      padding: .1em;
     }
 }


### PR DESCRIPTION
- adds data column to csv download and removes the block column
- update to paragraph about duplicate addresses
- print styles to account for the default to hide table rows
    - they should still be in the print view
- don't show result #'s if only 1 address is queried
- error for not choosing a file upload