### PR TITLE
fix a refresh bug with sammy.js

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -94,7 +94,7 @@ processAddresses = function(addresses) {
 var app = $.sammy(function() {
 
   this.before('/', function(context) {
-    if (context.path !== '/') {
+    if (context.path !== '' && context.path !== '/' && context.path !== '/rural-or-underserved-tool/') {
       window.location.href = 'http://www.consumerfinance.gov' + context.path;
     }
   });


### PR DESCRIPTION
fixes refresh bug by checking for /rural-or-underserved-tool/ and empty context.path

@jimmynotjim when pushing to dev and staging I noticed that it was auto-refreshing the `/rural-or-underserved-tool/` path was being caught by sammy and redirecting.