### PR TITLE
Fix broken search and make it use HTTPS

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -110,7 +110,7 @@
                  data-js-hook="flyout-menu_content"
                  aria-expanded="false">
                 <form class="m-global-search_content-form"
-                      action="http://search.consumerfinance.gov/search"
+                      action="https://search.consumerfinance.gov/search"
                       method="get">
                     <input type="hidden"
                            name="utf8"
@@ -146,22 +146,22 @@
                         <p class="h5">Suggested search terms:</p>
                         <ul class="list list__horizontal">
                             <li class="list_item">
-                                <a class="list_link" href="http://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=regulations">
+                                <a class="list_link" href="https://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=regulations">
                                     Regulations
                                 </a>
                             </li>
                             <li class="list_item">
-                                <a class="list_link" href="http://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=compliance+guides">
+                                <a class="list_link" href="https://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=compliance+guides">
                                     Compliance guides
                                 </a>
                             </li>
                             <li class="list_item">
-                                <a class="list_link" href="http://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=mortgage">
+                                <a class="list_link" href="https://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=mortgage">
                                     Mortgage
                                 </a>
                             </li>
                             <li class="list_item">
-                                <a class="list_link" href="http://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=college+loans">
+                                <a class="list_link" href="https://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=college+loans">
                                     College loans
                                 </a>
                             </li>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -91,7 +91,7 @@ processAddresses = function(addresses) {
   });
 }
 
-var app = $.sammy(function() {
+var app = $.sammy('main', function() {
 
   this.before('/', function(context) {
     if (context.path !== '' && context.path !== '/' && context.path !== '/rural-or-underserved-tool/') {


### PR DESCRIPTION
The consumerfinance.gov search form on the live Rural or Underserved Tool is currently broken. Visit [the live site](http://www.consumerfinance.gov/rural-or-underserved-tool/) and try entering a search in the upper right search box. It will fail with a malformed URL.

This PR fixes this behavior and also modifies search to use HTTPS (https://search.consumerfinance.gov) in preparation for the eventual cf.gov move to HTTPS.

## Testing

To verify that search works and uses HTTPS:

1. Checkout the repository.
2. Run `npm install` to install dependencies.
3. Run `grunt` to start a local server.
4. Open a browser to [http://localhost:9001](http://localhost:9001).
5. Enter a search in the form in the upper right search box, submit, and note that it goes to an HTTPS address like [this](https://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=test).

To verify existing functionality:

1. Try entering a single address manually on the left half of the page, e.g. "1600 Pennsylvania Ave NW, Washington, DC 20500". Click "Check addresses" and note that address checks work properly.
2. Try uploading a CSV file using the form on the right side of the page, with content like this:

 ```csv
 Street Address,City,State,Zip
 1600 Pennsylvania Ave NW,Washington,DC,20500
 ```

 Click "Check addresses" and note that address checks work properly.

## Review

@higs4281 

## Notes

This repo makes use of the [sammy](https://github.com/quirkey/sammy) JS library, and I had to make a change to how that library was invoked to restrict its scope to only some of the page content (otherwise it was breaking how the search box worked). @awolfe76 @wpears (or someone else who knows sammy) could you take a quick look and verify that my change seems reasonable?