### PR TITLE
Remove the "about us" featured content

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1494,33 +1494,6 @@
                 </div>
             </div>
 
-
-
-<aside class="m-featured-menu-content">
-    <div class="m-featured-menu-content_text">
-        <p class="h4">
-            <a href="/about-us/the-bureau/">
-                  The CFPB: Working for you
-            </a>
-        </p>
-        <p>
-            This short video covers what the CFPB is and how we are working for American consumers.
-        </p>
-    </div>
-    <a href="/about-us/the-bureau/"
-       class="m-featured-menu-content_img">
-        <img src="/static/img/fmc-about-us-540x300.jpg"
-             alt="Still from about the CFPB video."
-             height="150"
-             width="270">
-    </a>
-</aside>
-
-
-
-
-
-
         </div>
     </div>
 


### PR DESCRIPTION
This mirrors a recent change to the site as a whole.

https://github.com/cfpb/cfgov-refresh/pull/3613